### PR TITLE
Wider character range for more unicode support

### DIFF
--- a/src/tags.plugin.coffee
+++ b/src/tags.plugin.coffee
@@ -70,7 +70,7 @@ module.exports = (BasePlugin) ->
 			document = docpad.getFile({tag:tag})
 
 			# Create
-			tagName = tag.toLowerCase().replace(/[^a-z0-9]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '')
+			tagName = tag.toLowerCase().replace(/[^\u00C0-\u1FFF\u2C00-\uD7FF\w\d]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '')
 			documentAttributes =
 				data: JSON.stringify({tag}, null, '\t')
 				meta:


### PR DESCRIPTION
If tag contain non latin symbols it'll be removed, but, for, example, in russian language it make files with empty filenames before extension like for `блог` filename will be `.html.eco`. So many tags just missed. This solution allow to make files with national characters in names.
